### PR TITLE
#8 Enhanced plotly timeline visualization by adjusting y-coordinate for actions

### DIFF
--- a/utils/dataUtils.ts
+++ b/utils/dataUtils.ts
@@ -19,11 +19,15 @@ export function getIcon(subAction: string): string {
     return iconName ? icons[iconName] : '';
 }
 
-export function createActionsScatterData(timeStampsInDateString: Array<string>, subActions: Array<string>, annotations: Array<string>): Partial<Data> {
+export function createActionsScatterData(timeStampsInDateString: Array<string>, yValues: Array<number>, subActions: Array<string>, annotations: Array<string>): Partial<Data> {
+    // console.log(timeStampsInDateString);
+    // console.log(yValues);
+    // console.log(subActions);
+    // console.log(annotations);
     const iconText = subActions.map(subAction => getIcon(subAction));
     return {
         x: timeStampsInDateString,
-        y: new Array(timeStampsInDateString.length).fill(1),
+        y: yValues,
         mode: 'text',
         type: 'scatter',
         text: iconText,


### PR DESCRIPTION
This update improves the timeline visualization by starting the y-coordinates from 2 and incrementing by 0.5 for each different action item. It also ensures actions containing "Shock" are grouped on the same line.