### PR TITLE
Added dropdown menu to the dashboard to select from available simulation sessions

### DIFF
--- a/app/hooks/useActionsData.ts
+++ b/app/hooks/useActionsData.ts
@@ -5,18 +5,28 @@ import {ImageToggleItem, LayoutWithNamedImage} from '@/types';
 import {actionsDictionary} from '@/app/ui/components/constants';
 import PlotsFileSource from '@/app/utils/plotSourceProvider';
 
-export const useActionsData = () => {
+type AvailableDate = keyof typeof PlotsFileSource;
+
+export const useActionsData = (selectedDate: AvailableDate = Object.keys(PlotsFileSource)[0] as AvailableDate) => {
   const [actionGroupIcons, setActionGroupIcons] = useState<ImageToggleItem[]>([]);
   const [actionsData, setActionsData] = useState<Data[]>([]);
   const [actionsLayout, setActionsLayout] = useState<LayoutWithNamedImage>({images: []});
 
   useEffect(() => {
-    parseCsvData(PlotsFileSource.actions['09182024'].url, (plotData, layoutConfig, actionGroupIconMap) => {
+    const url = PlotsFileSource[selectedDate].actions.url;
+    if (!url) {
+      setActionsData([]);
+      setActionsLayout({images: []});
+      setActionGroupIcons([]);
+      return;
+    }
+
+    parseCsvData(url, (plotData, layoutConfig, actionGroupIconMap) => {
       setActionGroupIcons(Object.entries(actionGroupIconMap).map((entry) => ({value: entry[0], source: entry[1]})));
       setActionsData(plotData);
       setActionsLayout(layoutConfig);
     });
-  }, []);
+  }, [selectedDate]);
 
   const updateActionsData = (selectedMarkers: string[]) => {
     const filteredData = filterActionsData(actionsData, actionsLayout, selectedMarkers);

--- a/app/hooks/useGazeData.ts
+++ b/app/hooks/useGazeData.ts
@@ -2,24 +2,30 @@ import { useEffect, useState } from 'react';
 import PlotsFileSource from '@/app/utils/plotSourceProvider';
 import { processGazeData, transformGazeDataForPlotly } from '@/app/lib/processGazeData';
 
-type SourceNames = keyof typeof PlotsFileSource.visualAttention;
+type SourceNames = keyof typeof PlotsFileSource[string]['visualAttention'];
+type SimulationDate = keyof typeof PlotsFileSource;
 
-export function useGazeData(windowSize: number, selectedSource: SourceNames) {
+export function useGazeData(windowSize: number, selectedDate: SimulationDate, selectedSource: SourceNames) {
     const [plotData, setPlotData] = useState({} as ReturnType<typeof transformGazeDataForPlotly>);
 
     useEffect(() => {
         const fetchAndProcessData = async () => {
-            const response = await fetch(PlotsFileSource.visualAttention[selectedSource].url['09302024']);
+            const url = PlotsFileSource[selectedDate].visualAttention[selectedSource].url;
+            if (!url) {
+                setPlotData({} as ReturnType<typeof transformGazeDataForPlotly>);
+                return;
+            }
+
+            const response = await fetch(url);
             const data = await response.json();
 
             const categoryCounts = processGazeData(data, windowSize);
-
             const plotData = transformGazeDataForPlotly(categoryCounts);
             setPlotData(plotData);
         };
 
         fetchAndProcessData().catch(console.error);
-    }, [selectedSource, windowSize]);
+    }, [selectedDate, selectedSource, windowSize]);
 
     return [plotData, setPlotData] as const;
 }

--- a/app/lib/ActionsScatterPlotPoint.ts
+++ b/app/lib/ActionsScatterPlotPoint.ts
@@ -7,6 +7,7 @@ import {ActionImage, ImageWithName} from '@/types';
 export default class ActionsScatterPlotPoint {
     static readonly ERROR_MARKER_COLOR = 'red';
     static readonly CORRECT_MARKER_COLOR = 'green';
+    static readonly DEFAULT_Y_POSITION = 0;
 
     readonly x: CsvDateTimeStamp;
     readonly y: number;
@@ -22,8 +23,11 @@ export default class ActionsScatterPlotPoint {
 
     constructor(parsedCsvRow: ActionsCsvRow){
         this.x = parsedCsvRow.timeStamp;
-        this.y = actionsDictionary.get(parsedCsvRow.actionName).y;
         this.name = parsedCsvRow.actionName;
+        
+        const actionInfo = actionsDictionary.get(this.name);
+        this.y = actionInfo ? actionInfo.y : ActionsScatterPlotPoint.DEFAULT_Y_POSITION;
+        
         this.hovertext = parsedCsvRow.actionAnnotation;
         this.dataText = this.#extractImageText(this.name);
         this.icon = getIcon(this.name);

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,12 +10,19 @@ import {useActionsData} from '@/app/hooks/useActionsData';
 import VisualAttentionPlot from '@/app/ui/components/plots/VisualAttentionPlot';
 import SelectorButtonGroup from '@/app/ui/components/SelectorButtonGroup';
 import StickyDiv from '@/app/ui/components/StickyDiv';
+import DateSelector from '@/app/ui/components/DateSelector';
+import PlotsFileSource from '@/app/utils/plotSourceProvider';
+import {checkDataAvailability} from '@/app/utils/dataAvailability';
+
+type AvailableDate = keyof typeof PlotsFileSource;
 
 const Page = () => {
   const [currentTime, setCurrentTime] = useState<number>(0);
   const [selectedSource, setSelectedSource] = useState('teamLead');
+  const [selectedDate, setSelectedDate] = useState<AvailableDate>(Object.keys(PlotsFileSource)[0] as AvailableDate);
 
   const seekTo = useRef(0);
+  const dataAvailability = checkDataAvailability(selectedDate);
 
   const handleTimePointClick = (event: Readonly<PlotMouseEvent>) => {
     seekTo.current = Today.timeStampStringToSeconds(event.points[0].x as string);
@@ -26,11 +33,40 @@ const Page = () => {
     setCurrentTime(time);
   };
 
-  return (
-    <PlotContext.Provider value={useActionsData()}>
+  const handleDateChange = (date: string) => {
+    setSelectedDate(date as AvailableDate);
+  };
+
+  const actionsData = useActionsData(selectedDate);
+
+  if (!dataAvailability.hasAllData) {
+    return (
       <div className='flex flex-col justify-evenly'>
+        <DateSelector
+          selectedDate={selectedDate}
+          onDateChange={handleDateChange}
+        />
+        <div className="p-8 text-center text-gray-600">
+          Complete simulation data is not available for the selected date. Please select a different date.
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <PlotContext.Provider value={actionsData}>
+      <div className='flex flex-col justify-evenly'>
+        <DateSelector
+          selectedDate={selectedDate}
+          onDateChange={handleDateChange}
+        />
         <StickyDiv videoElementId="video">
-          <VideoPlayer videoElementId="video" onTimeUpdate={handleTimeUpdate} seekTo={seekTo.current} />
+          <VideoPlayer 
+            videoElementId="video" 
+            onTimeUpdate={handleTimeUpdate} 
+            seekTo={seekTo.current}
+            videoUrl={PlotsFileSource[selectedDate].video.url ?? ''}
+          />
         </StickyDiv>
         <FilteredActionsPlot currentTime={currentTime} onClick={handleTimePointClick} />
         <div className='flex flex-col items-center p-4'>
@@ -47,8 +83,16 @@ const Page = () => {
             }}
           />
         </div>
-        <CognitiveLoadPlot currentTime={currentTime} selectedSource={selectedSource} />
-        <VisualAttentionPlot currentTime={currentTime} selectedSource={selectedSource} />
+        <CognitiveLoadPlot 
+          currentTime={currentTime} 
+          selectedSource={selectedSource}
+          selectedDate={selectedDate}
+        />
+        <VisualAttentionPlot 
+          currentTime={currentTime} 
+          selectedSource={selectedSource}
+          selectedDate={selectedDate}
+        />
       </div>
     </PlotContext.Provider>
   );

--- a/app/ui/components/DateSelector.tsx
+++ b/app/ui/components/DateSelector.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import PlotsFileSource from '@/app/utils/plotSourceProvider';
+
+// Get available dates from the simulation dataset
+const availableDates = Object.keys(PlotsFileSource);
+
+interface DateSelectorProps {
+  selectedDate: string;
+  onDateChange: (date: string) => void;
+}
+
+const DateSelector: React.FC<DateSelectorProps> = ({
+  selectedDate,
+  onDateChange,
+}) => {
+  return (
+    <div className="flex items-center gap-4 p-4">
+      <label htmlFor="simulation-date" className="text-gray-700 font-medium">
+        Select simulation data:
+      </label>
+      <select
+        id="simulation-date"
+        value={selectedDate}
+        onChange={(e) => onDateChange(e.target.value)}
+        className="px-4 py-2 border rounded-md bg-white min-w-[120px] appearance-none cursor-pointer bg-[url('data:image/svg+xml;charset=utf-8,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 16 16%22><path fill=%22none%22 stroke=%22%23343a40%22 stroke-linecap=%22round%22 stroke-linejoin=%22round%22 stroke-width=%222%22 d=%22m2 5 6 6 6-6%22/></svg>')] bg-[length:16px_12px] bg-[right_0.5rem_center] bg-no-repeat pr-8"
+      >
+        {availableDates.map((date) => (
+          <option key={date} value={date}>
+            {date}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+};
+
+export default DateSelector; 

--- a/app/ui/components/VideoPlayer.tsx
+++ b/app/ui/components/VideoPlayer.tsx
@@ -1,10 +1,19 @@
 import React, {useEffect, useRef} from 'react';
 import 'tailwindcss/tailwind.css';
 
-// Set the local video path
-const localVideoUrl = 'https://www.dropbox.com/scl/fi/gzpo2mer8tigrit3npjxv/timeline-multiplayer-09182024.mp4?rlkey=6sbj1ru1qze8mmf2xgww5q9tt&st=1iu18zj4&dl=1'; //
+interface VideoPlayerProps {
+  videoElementId: string;
+  onTimeUpdate: (currentTime: number) => void;
+  seekTo: number | null;
+  videoUrl: string;
+}
 
-const VideoPlayer = ({videoElementId, onTimeUpdate, seekTo}: {videoElementId:string, onTimeUpdate: (currentTime:number)=>void, seekTo: number|null}) => {
+const VideoPlayer = ({
+  videoElementId,
+  onTimeUpdate,
+  seekTo,
+  videoUrl
+}: VideoPlayerProps) => {
   const videoRef = useRef({currentTime: 0} as HTMLVideoElement);
 
   const handleSeek = () => {
@@ -28,7 +37,7 @@ const VideoPlayer = ({videoElementId, onTimeUpdate, seekTo}: {videoElementId:str
       <div className="w-full max-w-2xl bg-gray-800 rounded-md overflow-hidden mb-4">
         <video id={videoElementId}
           ref={videoRef}
-          src={localVideoUrl}
+          src={videoUrl}
           controls
           className="w-full"
           onTimeUpdate={handleTimeUpdate}

--- a/app/ui/components/constants.ts
+++ b/app/ui/components/constants.ts
@@ -99,9 +99,10 @@ class ActionsDictionary{
     }, this);
   }
   getActionNamesByGroups(groupNames: string[]): string[] {
-    return groupNames.flatMap(group => ACTION_GROUP_MAP[group].names || []);
+    if (!groupNames.length) return [];
+    return groupNames.flatMap(group => ACTION_GROUP_MAP[group]?.names || []);
   }
-  get(action: string){
+  get(action: string): ActionImage | undefined {
     return this.#dictionary[action];
   }
   get yMax(): number {
@@ -121,8 +122,13 @@ export function getIcon(action: string): ActionImage {
     const icon = actionsDictionary.get(action);
 
     if (!icon) {
-        // console.error(`Icon not found for action: ${action} in explanationItems`);
-        return { url: '/icons/not-found.png', name: 'not found', group:'', y:0 };
+        console.warn(`Action not found in dictionary: ${action}`);
+        return { 
+            url: '/icons/not-found.png', 
+            name: action, 
+            group: 'Unknown', 
+            y: 0 
+        };
     }
 
     return icon;

--- a/app/ui/components/plots/CognitivePlot.tsx
+++ b/app/ui/components/plots/CognitivePlot.tsx
@@ -6,20 +6,30 @@ import PlotsFileSource from '@/app/utils/plotSourceProvider';
 import PulseLoader from '@/app/ui/components/PulseLoader';
 import {Data} from 'plotly.js';
 import addTimeTracer from '@/app/utils/addVideoTimeTracerToPlot';
+
 // Dynamically import Plotly with no SSR
 const Plot = dynamic(() => import('react-plotly.js'), {ssr: false});
 
-type SourceName = keyof typeof PlotsFileSource.cognitiveLoad;
+type SourceName = keyof typeof PlotsFileSource[string]['cognitiveLoad'];
+type SimulationDate = keyof typeof PlotsFileSource;
 
-const CognitiveLoadPlot = ({currentTime, selectedSource}: {currentTime:number, selectedSource: string}) => {
+const CognitiveLoadPlot = ({
+  currentTime, 
+  selectedSource,
+  selectedDate
+}: {
+  currentTime: number;
+  selectedSource: string;
+  selectedDate: SimulationDate;
+}) => {
   const {actionsLayout} = useContext(PlotContext);
-  const {cognitiveLoadData, cognitiveLoadLayout} = useCognitiveLoadData(selectedSource as SourceName);
+  const {cognitiveLoadData, cognitiveLoadLayout} = useCognitiveLoadData(selectedDate, selectedSource as SourceName);
   const plotData: Data[] = addTimeTracer(currentTime, cognitiveLoadData, {});
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
     setIsLoading(true); // Set loading state when selectedSource changes
-  }, [selectedSource]);
+  }, [selectedSource, selectedDate]);
 
   useEffect(() => {
     if (cognitiveLoadData && cognitiveLoadData[0] && cognitiveLoadLayout) {

--- a/app/ui/components/plots/VisualAttentionPlot.tsx
+++ b/app/ui/components/plots/VisualAttentionPlot.tsx
@@ -1,9 +1,9 @@
 'use client';
+import React, {useContext, useEffect, useState} from 'react';
 import {Data, Layout, Shape} from 'plotly.js';
 import dynamic from 'next/dynamic';
 import {useGazeData} from '@/app/hooks/useGazeData';
 import PlotsFileSource from '@/app/utils/plotSourceProvider';
-import React, {useContext, useEffect, useState} from 'react';
 import PlotContext from '@/app/ui/components/PlotContext';
 import PlotlyScatterLayout from '@/app/utils/plotly/PlotlyScatterLayout';
 import PulseLoader from '@/app/ui/components/PulseLoader';
@@ -13,39 +13,26 @@ const Plot = dynamic(() => import('react-plotly.js'), {ssr: false});
 
 const windowSize = 10; // 10-second window
 
-type SourceName = keyof typeof PlotsFileSource.visualAttention;
+type SourceName = keyof typeof PlotsFileSource[string]['visualAttention'];
+type SimulationDate = keyof typeof PlotsFileSource;
 
-// Generates vertical dotted line shapes separating stages/transitions using context actionsLayout.shapes
-const generateVerticalLineShapes = (shapesArray: Partial<Shape>[]): Partial<Shape>[] => {
-  // Extract unique x1 values for vertical lines
-  const uniqueX1Values = Array.from(new Set(shapesArray.map((shape) => shape.x1)));
-
-  // Create vertical line shapes for each unique x1 value
-  return uniqueX1Values.map((x1Value) => ({
-    type: 'line',
-    x0: x1Value,
-    x1: x1Value,
-    y0: 0,
-    y1: 1,
-    xref: 'x',
-    yref: 'paper',
-    line: {
-      color: 'black',
-      width: 2,
-      dash: 'dot'
-    }
-  })) as Partial<Shape>[];
-};
-
-const VisualAttentionPlot = ({currentTime, selectedSource}: {currentTime:number, selectedSource: string}) => {
+const VisualAttentionPlot = ({
+  currentTime,
+  selectedSource,
+  selectedDate
+}: {
+  currentTime: number;
+  selectedSource: string;
+  selectedDate: SimulationDate;
+}) => {
   const {actionsLayout} = useContext(PlotContext);
-  const [gazeData] = useGazeData(windowSize, selectedSource as SourceName);
+  const [gazeData] = useGazeData(windowSize, selectedDate, selectedSource as SourceName);
   const plotData: Data[] = addTimeTracer(currentTime, gazeData.plotlyData??[], {color:'#610C04'} );
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
     setIsLoading(true); // Set loading state when selectedSource changes
-  }, [selectedSource]);
+  }, [selectedSource, selectedDate]);
 
   useEffect(() => {
     if (gazeData && gazeData.plotlyData && gazeData.plotlyData[0]) {
@@ -76,31 +63,52 @@ const VisualAttentionPlot = ({currentTime, selectedSource}: {currentTime:number,
           ...layoutConfig.toPlotlyFormat(),
           ...({
             margin: {
-              // This is to position the title
-              t: 50, // Adjust this value to control the top margin
-              l: 50, // Left margin
-              r: 50, // Right margin
-              b: 50 // Bottom margin
+              t: 50,
+              l: 50,
+              r: 50,
+              b: 50
             },
             barmode: 'stack',
-            bargap: 0, // Remove gaps between bars
+            bargap: 0,
             xaxis: actionsLayout.xaxis,
             legend: {
-              orientation: 'h', // Set the legend to horizontal
-              x: 0.5, // Center the legend horizontally
-              y: 1, // Position the legend above the plot
+              orientation: 'h',
+              x: 0.5,
+              y: 1,
               xanchor: 'center',
               yanchor: 'bottom',
-              traceorder: 'normal' // Set trace order as normal to get the desired category order otherwise it's reversed
+              traceorder: 'normal'
             }
           } as Partial<Layout>)
         }}
         config={{displayModeBar: true, responsive: true, displaylogo: false}}
         style={{width: '100%', height: '100%'}}
-        useResizeHandler={true} // Ensure the plot adjusts size when container changes
+        useResizeHandler={true}
       />
     </div>
   );
+};
+
+// Generates vertical dotted line shapes separating stages/transitions using context actionsLayout.shapes
+const generateVerticalLineShapes = (shapesArray: Partial<Shape>[]): Partial<Shape>[] => {
+  // Extract unique x1 values for vertical lines
+  const uniqueX1Values = Array.from(new Set(shapesArray.map((shape) => shape.x1)));
+
+  // Create vertical line shapes for each unique x1 value
+  return uniqueX1Values.map((x1Value) => ({
+    type: 'line',
+    x0: x1Value,
+    x1: x1Value,
+    y0: 0,
+    y1: 1,
+    xref: 'x',
+    yref: 'paper',
+    line: {
+      color: 'black',
+      width: 2,
+      dash: 'dot'
+    }
+  })) as Partial<Shape>[];
 };
 
 export default VisualAttentionPlot;

--- a/app/utils/dataAvailability.ts
+++ b/app/utils/dataAvailability.ts
@@ -1,0 +1,21 @@
+import PlotsFileSource from '@/app/utils/plotSourceProvider';
+
+export const checkDataAvailability = (date: string) => {
+  const simulationData = PlotsFileSource[date];
+  if (!simulationData) return { hasActions: false, hasCognitiveLoad: false, hasVisualAttention: false, hasAllData: false };
+
+  const hasActions = simulationData.actions.url !== undefined;
+  const hasCognitiveLoad = Object.values(simulationData.cognitiveLoad).every(
+    source => source.url !== undefined
+  );
+  const hasVisualAttention = Object.values(simulationData.visualAttention).every(
+    source => source.url !== undefined
+  );
+
+  return {
+    hasActions,
+    hasCognitiveLoad,
+    hasVisualAttention,
+    hasAllData: hasActions && hasCognitiveLoad && hasVisualAttention
+  };
+}; 

--- a/app/utils/plotSourceProvider.ts
+++ b/app/utils/plotSourceProvider.ts
@@ -1,78 +1,182 @@
+interface DataSource {
+  name: string;
+  url: string | undefined;
+}
+
+interface CognitiveLoadData {
+  teamLead: DataSource;
+  average: DataSource;
+  defib: DataSource;
+  compressor: DataSource;
+  airway: DataSource;
+}
+
+interface VisualAttentionData {
+  teamLead: DataSource;
+  defib: DataSource;
+  compressor: DataSource;
+  airway: DataSource;
+}
+
+interface SimulationData {
+  video: DataSource;
+  actions: DataSource;
+  cognitiveLoad: CognitiveLoadData;
+  visualAttention: VisualAttentionData;
+}
+
+type SimulationDataset = Record<string, SimulationData>;
+
 const baseUrl = 'https://dl.dropboxusercontent.com/scl/fi';
-const PlotsFileSource = {
-  actions: {
-    '06102024': {
-      name: '06102024',
-      url: `${baseUrl}/vj6wm2c30u3qqk5kbuj9v/timeline-multiplayer-06102024.csv?rlkey=ztegai6tskj3jgbxjbwz5l393&st=ofuo2z4c&dl=0`
+
+const PlotsFileSource: SimulationDataset = {
+  '09302024': {
+    video: {
+      name: 'Video',
+      url: `${baseUrl}/gzpo2mer8tigrit3npjxv/timeline-multiplayer-09182024.mp4?rlkey=6sbj1ru1qze8mmf2xgww5q9tt&st=2gnlyx5i&dl=0`
     },
-    '08052024': {
-      name: '08052024',
-      url: `${baseUrl}/tjl0wfx0nebdkx0w7al6w/timeline-multiplayer-08052024.csv?rlkey=kh4h2s09ombtkbu1iqpp6b7pg&st=b9hozrus&dl=0`
+    actions: {
+      name: 'Actions Data',
+      url: `${baseUrl}/6os941r9qnk19nkd22415/timeline-multiplayer-09182024.csv?rlkey=4lpfpmkf62fnua597t7bh3p17&st=kgj7uu6l&dl=0`
     },
-    '09182024': {
-      name: '09182024',
-      url: `${baseUrl}/6os941r9qnk19nkd22415/timeline-multiplayer-09182024.csv?rlkey=4lpfpmkf62fnua597t7bh3p17&st=1v2zw6n3&dl=0`
+    cognitiveLoad: {
+      teamLead: {
+        name: 'Team Lead',
+        url: `${baseUrl}/6lmdyuka085hdpakzp7kn/team_lead_cognitive_load.json?rlkey=fm7881olmj0uu7j3zf111ebpd&st=cxwrqgo2&dl=0`
+      },
+      average: {
+        name: 'Average',
+        url: `${baseUrl}/qnbk37u8b749v181c1kwt/average_cognitive_load.json?rlkey=cb82ggqrn6rqcvi1f055u92zq&st=9eto5ucj&dl=0`
+      },
+      defib: {
+        name: 'Defibrillator',
+        url: `${baseUrl}/nhbt6rd1mz6tpseuxtk1d/defib_cognitive_load.json?rlkey=urn8azmqecma6p2vq7n4mogfg&st=1r44lsx1&dl=0`
+      },
+      compressor: {
+        name: 'Compressor',
+        url: `${baseUrl}/dy8mxgddiy9zo7ilefhde/compressor_cognitive_load.json?rlkey=1zqdqaqkqchollucv258za1z6&st=2m59wrfl&dl=0`
+      },
+      airway: {
+        name: 'Airway',
+        url: `${baseUrl}/v39rhujeqde7pj3r57xlk/airway_cognitive_load.json?rlkey=79b0094va3d4n6teq6zn4ko11&st=3n5gf8ie&dl=0`
+      }
     },
-    '09302024': {
-      name: '09302024',
-      url: `${baseUrl}/1ls2txjhf6y1yqeab37i9/timeline-multiplayer-09302024.csv?rlkey=3opuazpyvp606md15pnjaxm3q&st=dvi2kwwd&dl=0`
+    visualAttention: {
+      teamLead: {
+        name: 'Team Lead',
+        url: `${baseUrl}/ujv8zhqty08u2xmcb7mt9/team_lead_fixation_data.json?rlkey=ni6lwp5a6cx7ioe9ydr4uerxe&st=m90n3yjg&dl=0`
+      },
+      defib: {
+        name: 'Defibrillator',
+        url: `${baseUrl}/64rs4pjq7iyva4hceq553/defib_fixation_data.json?rlkey=3a22v8gqwym18iej2usarlmc2&st=t9kdd47x&dl=0`
+      },
+      compressor: {
+        name: 'Compressor',
+        url: `${baseUrl}/rnt4fk27e55xqmtgqdww5/cpr_fixation_data.json?rlkey=hdm0ara4on6it50dszif3ualx&st=khc7myuo&dl=0`
+      },
+      airway: {
+        name: 'Airway',
+        url: `${baseUrl}/natojy0easb7ckev55mgs/airway_fixation_data.json?rlkey=kqmpytb0i00xjrn8jy66arysq&st=u6amcn8x&dl=0`
+      }
     }
   },
-  cognitiveLoad: {
-    teamLead: {
-      name: 'Team Lead',
-      url: {
-        '09302024': `${baseUrl}/6lmdyuka085hdpakzp7kn/team_lead_cognitive_load.json?rlkey=fm7881olmj0uu7j3zf111ebpd&st=cxwrqgo2&dl=0`
+  '01092025 (invalid data)': {
+    video: {
+      name: 'Video',
+      url: undefined
+    },
+    actions: {
+      name: 'Actions Data',
+      url: undefined
+    },
+    cognitiveLoad: {
+      teamLead: {
+        name: 'Team Lead',
+        url: undefined
+      },
+      average: {
+        name: 'Average',
+        url: undefined
+      },
+      defib: {
+        name: 'Defibrillator',
+        url: undefined
+      },
+      compressor: {
+        name: 'Compressor',
+        url: undefined
+      },
+      airway: {
+        name: 'Airway',
+        url: undefined
       }
     },
-    average: {
-      name: 'Average',
-      url: {
-        '09302024': `${baseUrl}/qnbk37u8b749v181c1kwt/average_cognitive_load.json?rlkey=cb82ggqrn6rqcvi1f055u92zq&st=9eto5ucj&dl=0`
-      }
-    },
-    defib: {
-      name: 'Defibrillator',
-      url: {
-        '09302024': `${baseUrl}/nhbt6rd1mz6tpseuxtk1d/defib_cognitive_load.json?rlkey=urn8azmqecma6p2vq7n4mogfg&st=1r44lsx1&dl=0`
-      }
-    },
-    compressor: {
-      name: 'Compressor',
-      url: {
-        '09302024': `${baseUrl}/dy8mxgddiy9zo7ilefhde/compressor_cognitive_load.json?rlkey=1zqdqaqkqchollucv258za1z6&st=2m59wrfl&dl=0`
-      }
-    },
-    airway: {
-      name: 'Airway',
-      url: {
-        '09302024': `${baseUrl}/v39rhujeqde7pj3r57xlk/airway_cognitive_load.json?rlkey=79b0094va3d4n6teq6zn4ko11&st=3n5gf8ie&dl=0`
+    visualAttention: {
+      teamLead: {
+        name: 'Team Lead',
+        url: undefined
+      },
+      defib: {
+        name: 'Defibrillator',
+        url: undefined
+      },
+      compressor: {
+        name: 'Compressor',
+        url: undefined
+      },
+      airway: {
+        name: 'Airway',
+        url: undefined
       }
     }
   },
-  visualAttention: {
-    teamLead: {
-      name: 'Team Lead',
-      url: {
-        '09302024': `${baseUrl}/ujv8zhqty08u2xmcb7mt9/team_lead_fixation_data.json?rlkey=ni6lwp5a6cx7ioe9ydr4uerxe&st=m90n3yjg&dl=0`
+  '01012025 (copy of 09182024)': {
+    video: {
+      name: 'Video',
+      url: `${baseUrl}/gzpo2mer8tigrit3npjxv/timeline-multiplayer-09182024.mp4?rlkey=6sbj1ru1qze8mmf2xgww5q9tt&st=2gnlyx5i&dl=0`
+    },
+    actions: {
+      name: 'Actions Data',
+      url: `${baseUrl}/6os941r9qnk19nkd22415/timeline-multiplayer-09182024.csv?rlkey=4lpfpmkf62fnua597t7bh3p17&st=kgj7uu6l&dl=0`
+    },
+    cognitiveLoad: {
+      teamLead: {
+        name: 'Team Lead',
+        url: `${baseUrl}/6lmdyuka085hdpakzp7kn/team_lead_cognitive_load.json?rlkey=fm7881olmj0uu7j3zf111ebpd&st=cxwrqgo2&dl=0`
+      },
+      average: {
+        name: 'Average',
+        url: `${baseUrl}/qnbk37u8b749v181c1kwt/average_cognitive_load.json?rlkey=cb82ggqrn6rqcvi1f055u92zq&st=9eto5ucj&dl=0`
+      },
+      defib: {
+        name: 'Defibrillator',
+        url: `${baseUrl}/nhbt6rd1mz6tpseuxtk1d/defib_cognitive_load.json?rlkey=urn8azmqecma6p2vq7n4mogfg&st=1r44lsx1&dl=0`
+      },
+      compressor: {
+        name: 'Compressor',
+        url: `${baseUrl}/dy8mxgddiy9zo7ilefhde/compressor_cognitive_load.json?rlkey=1zqdqaqkqchollucv258za1z6&st=2m59wrfl&dl=0`
+      },
+      airway: {
+        name: 'Airway',
+        url: `${baseUrl}/v39rhujeqde7pj3r57xlk/airway_cognitive_load.json?rlkey=79b0094va3d4n6teq6zn4ko11&st=3n5gf8ie&dl=0`
       }
     },
-    defib: {
-      name: 'Defibrillator',
-      url: {
-        '09302024': `${baseUrl}/64rs4pjq7iyva4hceq553/defib_fixation_data.json?rlkey=3a22v8gqwym18iej2usarlmc2&st=t9kdd47x&dl=0`
-      }
-    },
-    compressor: {
-      name: 'Compressor',
-      url: {
-        '09302024': `${baseUrl}/rnt4fk27e55xqmtgqdww5/cpr_fixation_data.json?rlkey=hdm0ara4on6it50dszif3ualx&st=khc7myuo&dl=0`
-      }
-    },
-    airway: {
-      name: 'Airway',
-      url: {
-        '09302024': `${baseUrl}/natojy0easb7ckev55mgs/airway_fixation_data.json?rlkey=kqmpytb0i00xjrn8jy66arysq&st=u6amcn8x&dl=0`
+    visualAttention: {
+      teamLead: {
+        name: 'Team Lead',
+        url: `${baseUrl}/ujv8zhqty08u2xmcb7mt9/team_lead_fixation_data.json?rlkey=ni6lwp5a6cx7ioe9ydr4uerxe&st=m90n3yjg&dl=0`
+      },
+      defib: {
+        name: 'Defibrillator',
+        url: `${baseUrl}/64rs4pjq7iyva4hceq553/defib_fixation_data.json?rlkey=3a22v8gqwym18iej2usarlmc2&st=t9kdd47x&dl=0`
+      },
+      compressor: {
+        name: 'Compressor',
+        url: `${baseUrl}/rnt4fk27e55xqmtgqdww5/cpr_fixation_data.json?rlkey=hdm0ara4on6it50dszif3ualx&st=khc7myuo&dl=0`
+      },
+      airway: {
+        name: 'Airway',
+        url: `${baseUrl}/natojy0easb7ckev55mgs/airway_fixation_data.json?rlkey=kqmpytb0i00xjrn8jy66arysq&st=u6amcn8x&dl=0`
       }
     }
   }


### PR DESCRIPTION
Added a dropdown to the dashboard to select from available data sources. Currently data sources are defined in the plotSourceProvider. There is only one valid data for the simulation date 09/30/2024. Other sources are added to demonstrate the functionality of the dropdown. If data source is corrupted or not available, plots will not be displayed. Application expects dataset similar to the structure below.

```
'09302024': {
    video: {
      name: 'Video',
      url: data url comes here.
    },
    actions: {
      name: 'Actions Data',
      url: data url comes here.
    },
    cognitiveLoad: {
      teamLead: {
        name: 'Team Lead',
        url: data url comes here.
      },
      average: {
        name: 'Average',
        url: data url comes here.
      },
      defib: {
        name: 'Defibrillator',
        url: data url comes here.
      },
      compressor: {
        name: 'Compressor',
        url: data url comes here.
      },
      airway: {
        name: 'Airway',
        url: data url comes here.
      }
    },
    visualAttention: {
      teamLead: {
        name: 'Team Lead',
        url: data url comes here.
      },
      defib: {
        name: 'Defibrillator',
        url: data url comes here.
      },
      compressor: {
        name: 'Compressor',
        url: data url comes here.
      },
      airway: {
        name: 'Airway',
        url: data url comes here.
      }
    }
}
```
        